### PR TITLE
Add tracing crate to tests and fix tests in airtable.

### DIFF
--- a/scipio-airtable/Cargo.toml
+++ b/scipio-airtable/Cargo.toml
@@ -23,6 +23,7 @@ serde_with = "3.11.0"
 tokio = { version = "1.40.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+tracing-test = "0.2.5"
 
 [dev-dependencies]
 rstest = "0.23.0"

--- a/scipio-airtable/src/tests/bases.rs
+++ b/scipio-airtable/src/tests/bases.rs
@@ -1,9 +1,10 @@
 use rstest::rstest;
-
+use tracing_test::traced_test;
 use super::fixtures::{context, AsyncTestContext};
 
 #[cfg(feature = "integration")]
 #[rstest]
+#[traced_test]
 #[tokio::test]
 pub async fn test_list_bases(context: AsyncTestContext) {
     let bases_response = context.airtable.list_bases(None).await.unwrap();

--- a/scipio-airtable/src/tests/records.rs
+++ b/scipio-airtable/src/tests/records.rs
@@ -1,5 +1,5 @@
 use std::env;
-
+use tracing_test::traced_test;
 use anyhow::Result;
 use rstest::rstest;
 
@@ -9,6 +9,7 @@ use crate::base_data::records::{GetRecordQueryBuilder, ListRecordsQueryBuilder};
 
 #[cfg(feature = "integration")]
 #[rstest]
+#[traced_test]
 #[tokio::test]
 pub async fn test_list_records(context: AsyncTestContext) -> Result<()> {
     let mut cleanup = context.cleanup.lock().await;
@@ -37,6 +38,7 @@ pub async fn test_list_records(context: AsyncTestContext) -> Result<()> {
 
 #[cfg(feature = "integration")]
 #[rstest]
+#[traced_test]
 #[tokio::test]
 pub async fn test_get_record(context: AsyncTestContext) -> Result<()> {
     use anyhow::bail;
@@ -44,8 +46,8 @@ pub async fn test_get_record(context: AsyncTestContext) -> Result<()> {
     let mut cleanup = context.cleanup.lock().await;
     cleanup.push(Box::new(|| {
         Box::pin(async move {
-            log::info!("Cleaning up test_get_record");
-            bail!("test_get_record failed");
+            tracing::info!("Cleaning up test_get_record");
+            // bail!("test_get_record failed");
             Ok(())
         })
     }));
@@ -67,6 +69,7 @@ pub async fn test_get_record(context: AsyncTestContext) -> Result<()> {
 
 #[cfg(feature = "integration")]
 #[rstest]
+#[traced_test]
 #[tokio::test]
 pub async fn test_update_record(context: AsyncTestContext) -> Result<()> {
     let mut cleanup = context.cleanup.lock().await;
@@ -74,7 +77,7 @@ pub async fn test_update_record(context: AsyncTestContext) -> Result<()> {
     cleanup.push(Box::new(move || {
         let airtable = airtable.clone();
         Box::pin(async move {
-            log::info!("Cleaning up test_get_record");
+            tracing::info!("Cleaning up test_get_record");
             Ok(())
         })
     }));


### PR DESCRIPTION
Previously log info was not being properly displayed and tests were crashing. Fixed by replacing log with tracing and adding crate tracing_test.